### PR TITLE
Broadcast onComplete event when transition ends and value is 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,11 +68,13 @@ Progress.stop = function stop (state) {
 }
 
 Progress.reset = function reset (state) {
-  state.set({value: 0, active: false})
+  state.active.set(false)
+  state.value.set(0)
 }
 
 Progress.done = function done (state) {
-  state.set({value: 1, active: false})
+  state.active.set(false)
+  state.value.set(1)
 }
 
 Progress.render = function render (state, options) {

--- a/index.js
+++ b/index.js
@@ -5,14 +5,11 @@ var Observ = require('observ')
 var watch = require('observ/watch')
 var increment = require('observ-increment')
 var createStore = require('weakmap-shim/create-store')
-var valueEvent = require('value-event/value')
+var transitionEvent = require('transition-event')
 var Event = require('weakmap-event')
 var compare = require('pare')
 var extend = require('xtend')
 var h = require('virtual-dom/h')
-var Delegator = require('dom-delegator')
-
-Delegator().listenTo('transitionend')
 
 module.exports = Progress
 
@@ -109,7 +106,7 @@ function renderBar (state, options) {
   }
   var bar = {
     style: extend(style, options.bar || {}),
-    'ev-transitionend': valueEvent(state.channels.transitionend)
+    'ev-transitionend': transitionEvent.end(state.channels.transitionend)
   }
 
   return h('progress-bar', bar)

--- a/package.json
+++ b/package.json
@@ -22,21 +22,26 @@
   ],
   "devDependencies": {
     "degree": "~1.0.8",
+    "dispatch-event": "~1.0.0",
     "rent": "~2.0.0",
     "standard": "^6.0.0",
     "tape": "^4.0.0",
+    "thermometer": "~1.4.0",
     "value-pipe": "~1.0.0"
   },
   "files": [
     "index.js"
   ],
   "dependencies": {
+    "dom-delegator": "~13.1.0",
+    "dover": "~1.2.0",
     "observ": "~0.2.0",
     "observ-increment": "~1.0.1",
-    "observ-struct": "~6.0.0",
     "pare": "~1.0.0",
     "preflex": "~1.0.1",
+    "value-event": "~5.1.1",
     "virtual-dom": "~2.1.1",
+    "weakmap-event": "~2.0.6",
     "weakmap-shim": "~1.1.0",
     "xtend": "~4.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -33,13 +33,12 @@
     "index.js"
   ],
   "dependencies": {
-    "dom-delegator": "~13.1.0",
     "dover": "~1.2.0",
     "observ": "~0.2.0",
     "observ-increment": "~1.0.1",
     "pare": "~1.0.0",
     "preflex": "~1.0.1",
-    "value-event": "~5.1.1",
+    "transition-event": "~1.0.0",
     "virtual-dom": "~2.1.1",
     "weakmap-event": "~2.0.6",
     "weakmap-shim": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,9 @@
   "devDependencies": {
     "degree": "~1.0.8",
     "dispatch-event": "~1.0.0",
-    "rent": "~2.0.0",
     "standard": "^6.0.0",
     "tape": "^4.0.0",
     "thermometer": "~1.4.0",
-    "value-pipe": "~1.0.0"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dispatch-event": "~1.0.0",
     "standard": "^6.0.0",
     "tape": "^4.0.0",
-    "thermometer": "~1.4.0",
+    "thermometer": "~1.4.0"
   },
   "files": [
     "index.js"

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ var vtree = Progress.render(state)
 
 ##### data
 
-*Required*  
+*Required*
 Type: `object`
 
 Initial state data for the component. Returns an observable state (`{active, value}`.
@@ -38,14 +38,19 @@ Starts the progress meter, ticking the `value` every 200ms.
 
 Stops the progress meter.
 
-#### `Progress.reset` -> `undefined`
+#### `Progress.reset(state)` -> `undefined`
 
 Stops the progress meter and resets it to `{value: 0}`.
 
-#### `Progress.done` -> `undefined`
+#### `Progress.done(state)` -> `undefined`
 
 Animates the progress meter to its final state (`{value: 1, active: false}`).
 
+#### `Progress.onComplete(state, listener)` -> `function`
+
+The listener is called when the progress bar's value is 1 and its transition ends.
+
+Returns an unlisten function.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@
 var test = require('tape')
 var rent = require('rent')
 var pipe = require('value-pipe')
+var dispatchEvent = require('dispatch-event')
+var createComponent = require('thermometer').createComponent
 var Progress = require('./')
 
 test(function (t) {
@@ -15,8 +17,30 @@ test(function (t) {
   t.equal(render().properties.style.transform, 'translate3d(-50%, 0, 0)')
 
   t.end()
+
+  function bar (vtree) {
+    return vtree.children[0].children[0]
+  }
 })
 
-function bar (vtree) {
-  return vtree.children[0].children[0]
-}
+test('onComplete', function (t) {
+  t.plan(1)
+
+  createComponent(Progress, function (state, element, done) {
+    Progress.onComplete(state, function () {
+      t.equal(state.value(), 1)
+    })
+
+    state.value.set(0.5)
+    dispatchEvent(bar(element), 'transitionend')
+
+    state.value.set(1)
+    dispatchEvent(bar(element), 'transitionend')
+
+    done()
+  })
+
+  function bar (element) {
+    return element.childNodes[0].childNodes[0]
+  }
+})

--- a/test.js
+++ b/test.js
@@ -1,26 +1,25 @@
 'use strict'
 
 var test = require('tape')
-var rent = require('rent')
-var pipe = require('value-pipe')
 var dispatchEvent = require('dispatch-event')
 var createComponent = require('thermometer').createComponent
 var Progress = require('./')
 
 test(function (t) {
   var state = Progress()
-  var render = pipe(rent(Progress.render, state), bar)
 
-  t.equal(render().properties.style.transform, 'translate3d(-100%, 0, 0)')
+  createComponent(Progress, state(), function (state, element, done) {
+    t.equal(bar(element).style.transform, 'translate3d(-100%, 0, 0)')
+    done()
+  })
 
   state.value.set(0.5)
-  t.equal(render().properties.style.transform, 'translate3d(-50%, 0, 0)')
+  createComponent(Progress, state(), function (state, element, done) {
+    t.equal(bar(element).style.transform, 'translate3d(-50%, 0, 0)')
+    done()
+  })
 
   t.end()
-
-  function bar (vtree) {
-    return vtree.children[0].children[0]
-  }
 })
 
 test('onComplete', function (t) {
@@ -39,8 +38,8 @@ test('onComplete', function (t) {
 
     done()
   })
-
-  function bar (element) {
-    return element.childNodes[0].childNodes[0]
-  }
 })
+
+function bar (element) {
+  return element.childNodes[0].childNodes[0]
+}


### PR DESCRIPTION
Just opening this for early feedback.

Use case: think iMessage. You send a message, the loader goes across the top, then once the message is successfully delivered it finishes the progress animation and then the loader disappears.

This enables this functionality by setting the value to 1, then once onComplete fires stop rendering the progress bar.

The downside? These changes do make this library a lot bigger -- we've added dependencies to `value-event`, `weakmap-event`, and `dover` -- but I think it's worth it for this functionality.

Todo:
- [x] We're now using both `rent` and `thermometer` to run tests. That should be consolidated to thermometer only.
- [x] The transitionend event handling and Delegator.listenTo should be in its own library. I'll do that and amend this PR later.
